### PR TITLE
Socket test: Added RT and prettified exceptions

### DIFF
--- a/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
+++ b/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
@@ -38,20 +38,31 @@ public class NetworkUtils {
 	}
 
 	public static String testConnect(String host, String port) {
+		long startTime = System.nanoTime();
+		long totalTime = System.nanoTime();
 		try {
 			Socket socket = new Socket();
+			startTime = System.nanoTime();
 			socket.connect(new InetSocketAddress(host, Integer.parseInt(port)), 10000);
 			socket.setSoTimeout(10000);
 			if (socket.isConnected()) {
+				totalTime = System.nanoTime() - startTime;
 				socket.getInputStream();
 			}
 			socket.close();
-		} catch (Exception e) {
+		} 
+		catch (java.net.UnknownHostException e) {
+			return "Could not resolve host " + host;
+		}
+		catch (java.net.SocketTimeoutException e) {
+			return "Timeout while trying to connect to " + host;
+		}
+		catch (Exception e) {
 			ByteArrayOutputStream b = new ByteArrayOutputStream();
 			e.printStackTrace(new PrintStream(b));
 			return b.toString();
 		}
-		return "Connection successful";
+		return "Connection successful, RTT=" + Long.toString(totalTime/1000000) + "ms";
 	}
 
 	public static String traceRoute(String host) throws Exception {


### PR DESCRIPTION
I've added RTT results to the socket test. Even though the RTT results should be similar to those of the ping test, it won't always be the same. It's also good to test latency to a specific service or for when ICMP is blocked.

I've also prettified the output for a couple of exceptions (resolution failure and timeout) also in the socket test.