### PR TITLE
Removed -E from curl test

### DIFF
--- a/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
+++ b/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
@@ -46,8 +46,7 @@ public class NetworkUtils {
 		//-i include protocol headers
 		//-L follow redirects
 		//-k insecure
-		//-E cert status
-		return execute(new ProcessBuilder("curl","-k", "-E", "-i","-L", url));
+		return execute(new ProcessBuilder("curl","-k", "-i","-L", url));
 	}
 
 	public static String testConnect(String host, String port) {


### PR DESCRIPTION
-E cert status not needed and (reported) causing failures