### PR TITLE
Enable to override http listener port for DLB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Last build can be found here: https://github.com/mulesoft-labs/net-tools-api/rel
 The UI can be access hitting *http://{app-name}.cloudhub.io*. It is protected by Basic Auth, the default credentials are "vpc-tools"/"SomePass". You can change those credentials setting "user" and "pass" properties in the CloudHub UI while deploying.
 
 You can also use the API Console accessing *http://{app-name}.cloudhub.io/api/console*.
+
+If you want to use the app with a dedicated load balancer, you need to set 8092 (or 8091) to "port" property in the CloudHub UI. See [VPC Network Architecture](https://docs.mulesoft.com/runtime-manager/vpc-architecture-concept) document for more details.

--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -3,8 +3,9 @@
 http://www.mulesoft.org/schema/mule/spring http://www.mulesoft.org/schema/mule/spring/current/mule-spring.xsd
 http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd
 http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
+    <global-property name="port" value="8081"/>
     <http:listener-config name="net-tools-httpListenerConfig">
-        <http:listener-connection host="0.0.0.0" port="8081" />
+        <http:listener-connection host="0.0.0.0" port="${port}" />
     </http:listener-config>
     <apikit:config name="net-tools-config" raml="net-tools.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
     	<spring:config name="Spring_Config" doc:id="3b613b3b-3bc8-47ee-897c-e00fe681b775" files="beans.xml" />


### PR DESCRIPTION
This change enable to override http listener port via Runtime Manager Properties. The feature is  very useful when we only can access the tool via DLB.
