### PR TITLE
Enable to send http headers in the curl.

### DIFF
--- a/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
+++ b/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
@@ -43,14 +43,14 @@ public class NetworkUtils {
 		}
 	}
 
-	public static String curl(String url, String[] headers) throws IOException {
+	public static String curl(String url, String[] headers, Boolean insecure) throws IOException {
 		//-i include protocol headers
 		//-L follow redirects
 		//-k insecure
 		//-E cert status
 		List<String> command = new ArrayList<String>();
 		command.add("curl");
-		command.add("-k");
+		if(insecure) command.add("-k");
 		command.add("-i");
 		command.add("-L");
 		command.add(url);

--- a/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
+++ b/src/main/java/com/mulesoft/tool/network/NetworkUtils.java
@@ -8,7 +8,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
-
+import java.util.ArrayList;
+import java.util.List;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.BufferedWriter;
@@ -42,12 +43,22 @@ public class NetworkUtils {
 		}
 	}
 
-	public static String curl(String url) throws IOException {
+	public static String curl(String url, String[] headers) throws IOException {
 		//-i include protocol headers
 		//-L follow redirects
 		//-k insecure
 		//-E cert status
-		return execute(new ProcessBuilder("curl","-k", "-i","-L", url));
+		List<String> command = new ArrayList<String>();
+		command.add("curl");
+		command.add("-k");
+		command.add("-i");
+		command.add("-L");
+		command.add(url);
+		for (String header : headers ) {
+			command.add("-H");
+			command.add(header);
+		}		
+		return execute(new ProcessBuilder(command));
 	}
 
 	public static String testConnect(String host, String port) {

--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -158,7 +158,7 @@ output application/json
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [])]]></ee:set-payload>
+NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean)]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
     </flow>

--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -158,7 +158,7 @@ output application/json
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::curl(attributes.queryParams.url)]]></ee:set-payload>
+NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [])]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
     </flow>

--- a/src/main/resources/api/net-tools.raml
+++ b/src/main/resources/api/net-tools.raml
@@ -91,6 +91,12 @@ securitySchemes:
       url:
         description: Target URL
         type: string 
+      header:
+        required: false
+        items:
+          type: string
+          example: |
+            Authorization:Basic YQxhZGRpbjpvcGVuc2VzYW1l
     responses: 
       200:
         body: 

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -149,6 +149,7 @@
                 <input name="ip" placeholder="IP Address or Host" type="text" title="IP" id="ip" />
                 <input name="port" placeholder="Port" type="text" title="PORT" id="port" />
                 <input name="url" placeholder="http://host:port/path/" type="text" title="URL" id="url" />
+                <input name="insecure" type="checkbox" title="insecure" id="insecure" checked="true" /><span class="helpBox" id="insecure_label">insecure</span>
                 <textarea name="header" placeholder="header-name:header-value" title="Header" id="header" rows="3" cols="50" style="display: block"></textarea>
                 <input name="dnsServer" placeholder="dns server" type="text" title="DNS SERVER" id="dnsServer" />
                 <button type="button" id="check">Run</button>
@@ -226,6 +227,8 @@
                         $("#url").show();
                         $("#curlHelp").show();
                         $("#header").show();
+                        $("#insecure").show();
+                        $("#insecure_label").show();
                         break;
                     default:
 
@@ -266,6 +269,7 @@
                     }
                     if (operation === 'curl') {
                         apiurl += '&url=' + encodeURI(url);
+                        apiurl += '&insecure=' + $("#insecure").prop('checked');
                         for (let h of $("#header").val().split('\n')) {
                         	apiurl += '&header=' + encodeURI(h);
                         }

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -149,6 +149,7 @@
                 <input name="ip" placeholder="IP Address or Host" type="text" title="IP" id="ip" />
                 <input name="port" placeholder="Port" type="text" title="PORT" id="port" />
                 <input name="url" placeholder="http://host:port/path/" type="text" title="URL" id="url" />
+                <textarea name="header" placeholder="header-name:header-value" title="Header" id="header" rows="3" cols="50" style="display: block"></textarea>
                 <input name="dnsServer" placeholder="dns server" type="text" title="DNS SERVER" id="dnsServer" />
                 <button type="button" id="check">Run</button>
                 <button type="button" id="clean">Clean Console</button>
@@ -159,7 +160,7 @@
 			  <div class="helpBox" id="tracerouteHelp" style="display: none;">Set an IP Address or Hostname and hit Run</div>	
               <div class="helpBox" id="socketHelp" style="display: none;">Set an IP Address or Hostname, the Port and hit Run</div>	
 			  <div class="helpBox" id="dnsHelp" style="display: none;">Set a Hostname and hit Run</div>	
-			  <div class="helpBox" id="curlHelp" style="display: none;">Set an IP Address or Schema (http-https://) plus Hostname, the Port, the Path and hit Run</div>	
+			  <div class="helpBox" id="curlHelp" style="display: none;">Set an IP Address or Schema (http-https://) plus Hostname, the Port, the Path, the Headers (multi-line) and hit Run</div>	
 			</div>
             <pre id="output">
             </pre>
@@ -188,6 +189,8 @@
                     var operation = e.target.value;
                     var inputs = $("#theForm input").removeClass();
                     inputs.hide();
+                    var textareas = $("#theForm textarea").removeClass();
+                    textareas.hide();
                     var helps = $(".helpBox");
                     helps.hide();
                     switch (operation) {
@@ -222,6 +225,7 @@
                       case "curl":
                         $("#url").show();
                         $("#curlHelp").show();
+                        $("#header").show();
                         break;
                     default:
 
@@ -262,6 +266,9 @@
                     }
                     if (operation === 'curl') {
                         apiurl += '&url=' + encodeURI(url);
+                        for (let h of $("#header").val().split('\n')) {
+                        	apiurl += '&header=' + encodeURI(h);
+                        }
                     }
                     console.log(operation + " " + ip + " " + port + " " + url );
                     $("#check").attr("disabled", true);


### PR DESCRIPTION
This change enable to send http headers in the curl.
This is useful such as checking backend APIs that require authentication.
Multiple headers can be specified with a new line.
